### PR TITLE
version locking upstream binaries

### DIFF
--- a/01_verify_source_code_pipeline/verify-commit-signature-task.yaml
+++ b/01_verify_source_code_pipeline/verify-commit-signature-task.yaml
@@ -37,9 +37,9 @@ spec:
     script: |
 
       ## Installs
-      go install github.com/sigstore/rekor/cmd/rekor-cli@latest
-      go install github.com/itchyny/gojq/cmd/gojq@latest
-      go install github.com/sigstore/gitsign@latest
+      go install github.com/sigstore/rekor/cmd/rekor-cli@v1.3.1
+      go install github.com/itchyny/gojq/cmd/gojq@v0.12.13
+      go install github.com/sigstore/gitsign@v0.7.1
 
       ## Task Logging
       set -x 


### PR DESCRIPTION
Addresses: [SECURESIGN-201](https://issues.redhat.com/browse/SECURESIGN-201).
 @bouskaJ 
/cc @lance I will swap them out to our components but wanted to make the easy fix first so there is something in master that currently works.